### PR TITLE
Fix nonstatic sidebar from scrolling in desktop view (fixes #86)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
+    concurrent-ruby (1.1.7)
     ffi (1.13.1)
     ffi (1.13.1-x64-mingw32)
     forwardable-extended (2.6.0)
@@ -18,10 +19,12 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.9.2)
+    jekyll-feed (0.11.0)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-theme-hyde (2.0.0)
       jekyll (~> 3.3)
     jekyll-watch (1.5.1)
@@ -32,11 +35,13 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    minima (2.1.1)
-      jekyll (~> 3.3)
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -47,10 +52,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    thread_safe (0.3.6)
-    tzinfo (1.2.3)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2017.2)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2020.2)
       tzinfo (>= 1.0.0)
 
 PLATFORMS
@@ -65,4 +69,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/assets/css/hyde.css
+++ b/assets/css/hyde.css
@@ -61,7 +61,7 @@ html {
 }
 @media (min-width: 48em) {
   .sidebar {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 18rem;


### PR DESCRIPTION
This was a pretty simple fix it looks like. I just set the position to be fixed when it's in desktop mode.

I did however update the Gemfile.lock to be able to test locally...many gems were too out of date (namely, bundle itself) for me to be able to run the local server. All of these changes would typically still be compatible with Github Pages though, enforced by dependencies of the github-pages plugin, but I just noticed that the github-pages plugin isn't enabled on this site. Any idea why?

If you can cherry-pick changes from my pull request, that might be desirable for now.