### PR TITLE
Update Release.yml

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5.1
+
+    #Fixing the bundle issue noted here: https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html
+    - run: gem install bundler -v 2.1.4
     - run: bundle install
     - run: bundle exec jekyll build -d _site/
     


### PR DESCRIPTION
* Fixing the Gem Bundler issue based on the lock file
* Fixed hyperlinked [here](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html)